### PR TITLE
Handle "icon" being preceeded with another token

### DIFF
--- a/packages/check-favicon/src/desktop/desktop.ts
+++ b/packages/check-favicon/src/desktop/desktop.ts
@@ -135,7 +135,7 @@ export const checkPngFavicon = async (baseUrl: string, head: HTMLElement | null,
     return { messages, icon: { content: null, url: null, width: null, height: null } };
   }
 
-  const icons = head?.querySelectorAll("link[rel='icon'][type='image/png']");
+  const icons = head?.querySelectorAll("link[rel~='icon'][type='image/png']");
   if (icons.length === 0) {
     messages.push({
       status: CheckerStatus.Error,


### PR DESCRIPTION
Currently, the lookup for PNG favicon only looks for "icon" in 'rel='.
This changes from doing an equality match to a contains match.
Rationale:
I am using "alternate" in front of "icon" for my PNG as I have SVG as the only one with "icon" by itself. However, it is still in my HTML and should therefore be discoverable.