### PR TITLE
fix: favicon.ico detection

### DIFF
--- a/packages/check-favicon/src/desktop/ico.ts
+++ b/packages/check-favicon/src/desktop/ico.ts
@@ -21,9 +21,10 @@ export const checkIcoFavicon = async (url: string, head: HTMLElement | null, fet
     };
   }
 
-  const icos =
-    head.querySelectorAll('link[rel="shortcut icon"]') ||
-    head.querySelectorAll('link[rel="icon"][type="image/x-icon"]');
+  const icos = [
+    ...head.querySelectorAll('link[rel="shortcut icon"]'),
+    ...head.querySelectorAll('link[rel="icon"][type="image/x-icon"]')
+  ];
 
   let iconUrl: string | null = null;
   let images;


### PR DESCRIPTION
This PR fixes the false negative test result on `favicon.ico`(icon is actually there, test erroneously says that it is not) 
<img src="https://github.com/user-attachments/assets/4230f9bc-f06b-4182-8aba-14f36267b6cc" width="30%" />

**Explanation:**
1. `querySelectorAll` always returns `HTMLElement[]`
2. If the first selector does not match any elements the return value is `[]` (empty array)
3. `[]` (empty array) is a truthy value, so `[] || <second selector>` will just return `[]`
4. As a result the second selector is never executed

**Solution:**
Always execute both selectors, and use their combined result

**Bonus:**
This will also fix the check of multiple favicon.ico files being present in case they are matched by both selectors:
```js
} else if (icos.length > 1) {
  messages.push({
    status: CheckerStatus.Error,
    id: MessageId.multipleIcoFavicons,
    text: `There are ${icos.length} ICO favicons`
  });
}
  ```
  
 P.S.: @phbernard Thanks a lot for your work. Have been using [RealFaviconGenerator](https://realfavicongenerator.net/) for many years!